### PR TITLE
Add Prisma setup step in build workflow

### DIFF
--- a/.github/workflows/build-capabilities.yml
+++ b/.github/workflows/build-capabilities.yml
@@ -27,5 +27,7 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install
+      - name: Set up Prisma
+        run: pnpm prisma generate
       - name: Build with Next.js
         run: pnpm next build


### PR DESCRIPTION
This is attempt to make build process work as expected. This PR Include a step to set up Prisma in the build workflow to ensure proper generation of the Prisma client.